### PR TITLE
refactor: use generics to elementRefs instead of assertion

### DIFF
--- a/src/components/planner/result/PlannerCard.vue
+++ b/src/components/planner/result/PlannerCard.vue
@@ -16,7 +16,7 @@ const props = defineProps({
 });
 
 const { t } = useI18n()
-const scrollDiv = ref(null);
+const scrollDiv = ref<HTMLDivElement | null>(null);
 
 const shouldHideScrollbar = computed(() => {
     return props.card.materials.length < 4;
@@ -33,7 +33,7 @@ const toolTipText = computed(() => {
 
 watch(shouldHideScrollbar, (newVal) => {
     if (newVal && scrollDiv.value) {
-        (scrollDiv.value as HTMLDivElement).scrollLeft = 0;
+        scrollDiv.value.scrollLeft = 0;
     }
 });
 

--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts" name="ProfileView">
-import { ref, Ref } from 'vue'
+import { ref } from 'vue'
 import { exportKornblumeData, importKornblumeData, resetKornblumeData } from '@/utils';
 import { usePullsRecordStore } from '@/stores/pullsRecordStore';
 
-const fileInput = ref(null)
+const fileInput = ref<HTMLElement>(null!)
 
 const exportStores = () => {
     exportKornblumeData()
@@ -11,7 +11,7 @@ const exportStores = () => {
 
 const triggerFileInput = () => {
     // Trigger the file input programmatically
-    (fileInput as Ref<HTMLElement | null>).value?.click()
+    fileInput.value.click()
 }
 
 const importStores = (event) => {

--- a/src/views/TrackerView.vue
+++ b/src/views/TrackerView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, Ref, watchEffect, onMounted, watch } from 'vue'
+import { ref, computed, watchEffect, onMounted, watch } from 'vue'
 import { useDataStore } from '@/stores/dataStore';
 import { IPull, usePullsRecordStore } from '../stores/pullsRecordStore'
 import { bannerList, bannerRateUp, specialArcanists } from '@/utils/bannerData'
@@ -8,7 +8,7 @@ import Tesseract, { createWorker } from 'tesseract.js';
 import Fuse, { FuseResult } from 'fuse.js';
 import TrackerBoard from '../components/tracker/TrackerBoard.vue';
 
-const fileInput = ref(null);
+const fileInput = ref<HTMLElement>(null!);
 const isImporting = ref(false);
 const currentFileIndex = ref(0);
 const totalFiles = ref(0);
@@ -19,11 +19,11 @@ const wrongTimestamps = ref<number[]>([]);
 const selectedBannerType = ref('Limited');
 const pulls = ref<IPull[]>([]);
 const changelogsStore = useChangelogsStore();
-const tutorialButton = ref(null);
+const tutorialButton = ref<HTMLButtonElement>(null!);
 
 const triggerFileInput = () => {
     // Trigger the file input programmatically
-    (fileInput as Ref<HTMLElement | null>).value?.click()
+    fileInput.value.click()
 }
 
 const isEqualPull = (pull1, pull2) => {
@@ -404,7 +404,7 @@ onMounted(() => {
     if (!changelogsStore.isOpenTutorial) {
         console.log(tutorialButton.value);
         if (tutorialButton.value) {
-            (tutorialButton.value as unknown as HTMLButtonElement).click();
+            tutorialButton.value.click();
         }
         changelogsStore.setIsOpenTutorial(true)
     }


### PR DESCRIPTION
# Description:

use generics to define type of HTMLElement, then we can use the Ref varible every where without assertion.

# Changes:

refactor all files use assertion to discribe HTMLElement type.
- components/planner/Result.vue
- views/ProfileView.vue
- views/TrackView.vue