### PR TITLE
Mobile enhancements + dev QoL

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -287,3 +287,14 @@
     --tooltip-text-color: var(--fallback-nc,oklch(var(--nc)/1));
     --tooltip-tail-offset: calc(100% + 0.0625rem/* 1px */ - var(--tooltip-tail));
 }
+
+/* Hide number input arrows */
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+input[type=number] {
+    -moz-appearance: textfield;
+}

--- a/src/components/item/ItemGoalIcon.vue
+++ b/src/components/item/ItemGoalIcon.vue
@@ -11,12 +11,9 @@ const props = defineProps({
     }
 });
 
-const checkQuantity = () => {
-    if (props.material.Quantity > 99 || useWarehouseStore().getItemQuantity(props.material.Material) > 99) {
-        return true;
-    }
-    return false;
-};
+const isWide = computed(() => {
+    return props.material.Quantity > 99 || useWarehouseStore().getItemQuantity(props.material.Material) > 99;
+});
 
 const getNormalizedMaterial = computed(() => {
     return normalizeDisplayMaterial(props.material);
@@ -28,12 +25,12 @@ const getNormalizedMaterial = computed(() => {
     <div class="tooltip" :data-tip="$t(getNormalizedMaterial.material)">
         <div class="relative inline-block">
             <img :src="getNormalizedMaterial.borderImagePath" alt="Border Image" class="w-20 h-20 absolute"
-                :class="{ 'w-36': checkQuantity() }" />
+                :class="{ 'w-36': isWide }" />
             <img :src="getNormalizedMaterial.itemImagePath" alt="Material Image" class="w-20 h-20 avatar"
-                :class="{ 'mx-5': checkQuantity() }" />
+                :class="{ 'mx-5': isWide }" />
             <div class="flex items-center justify-center small-text text-white absolute -bottom-3 left-3 input input-xs rounded-t-none"
                 :class="{
-        'left-[17px] w-[85px]': checkQuantity(), 'w-14': !checkQuantity(),
+        'left-[17px] w-[85px]': isWide, 'w-14': !isWide,
         'bg-green-800/80': useWarehouseStore().getItemQuantity(props.material.Material) >= props.material.Quantity, 'bg-red-500/60': useWarehouseStore().getItemQuantity(props.material.Material) < props.material.Quantity
     }">
                 {{ formatQuantity(useWarehouseStore().getItemQuantity(getNormalizedMaterial.material)) }} / {{

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -1,16 +1,12 @@
 <script lang="ts" setup name="Navbar">
-import { onMounted, ref, watchEffect } from 'vue';
+import { onMounted, ref } from 'vue';
 import { setLocale, supportedLangCodes, langDropdownOptions } from '@/utils/i18n';
 import Popper from 'vue3-popper';
+import { useScreen } from '@/composables/useScreen';
 
-const isSmallScreen = ref(window.innerWidth <= 768);
-const showDropdown = ref(false);
+const { isLargeScreen } = useScreen();
 const currentLanguage = ref('English');
 const currentFlag = ref('fi fi-us');
-
-const toggleDropdown = () => {
-    showDropdown.value = !showDropdown.value;
-};
 
 const handleChangeLanguage = ({ locale, text, icon }) => {
     currentLanguage.value = text;
@@ -34,22 +30,6 @@ onMounted(() => {
         handleChangeLanguage(option);
     }
 });
-
-watchEffect(() => {
-    const handleResize = () => {
-        isSmallScreen.value = window.innerWidth <= 1024;
-        if (!isSmallScreen.value) {
-            showDropdown.value = false;
-        }
-    };
-
-    window.addEventListener('resize', handleResize);
-    handleResize(); // Initial check
-
-    return () => {
-        window.removeEventListener('resize', handleResize);
-    };
-});
 </script>
 
 <template>
@@ -59,7 +39,7 @@ watchEffect(() => {
         /></router-link>
 
         <!-- Navigation Links for Large Screens -->
-        <div v-if="!isSmallScreen" class="flex space-x-2">
+        <div v-if="isLargeScreen" class="flex space-x-2">
             <router-link to="/" class="nav-button" :class="{ active: $route.path === '/' }"
                 ><i class="fa-solid fa-house"></i> {{ $t('home') }}
             </router-link>
@@ -135,7 +115,7 @@ watchEffect(() => {
             </Popper>
 
             <!-- Dropdown Button for Small Screens -->
-            <div v-if="isSmallScreen">
+            <div v-if="!isLargeScreen">
                 <Popper arrow placement="top" offsetDistance="2">
                     <div class="nav-button cursor-pointer">
                         <i class="fa-solid fa-bars text-white"></i>
@@ -143,48 +123,28 @@ watchEffect(() => {
                     <template #content="{ close }">
                         <div class="flex flex-col space-y-2">
                             <router-link
-                                @click="
-                                    () => {
-                                        toggleDropdown();
-                                        close();
-                                    }
-                                "
+                                @click="close"
                                 to="/"
                                 class="nav-button block"
                                 :class="{ active: $route.path === '/' }"
                                 ><i class="fa-solid fa-house"></i> {{ $t('home') }}
                             </router-link>
                             <router-link
-                                @click="
-                                    () => {
-                                        toggleDropdown();
-                                        close();
-                                    }
-                                "
+                                @click="close"
                                 to="/arcanists"
                                 class="nav-button block"
                                 :class="{ active: $route.path === '/arcanists' }"
                                 ><i class="fa-solid fa-user"></i> {{ $t('arcanists') }}
                             </router-link>
                             <router-link
-                                @click="
-                                    () => {
-                                        toggleDropdown();
-                                        close();
-                                    }
-                                "
+                                @click="close"
                                 to="/items"
                                 class="nav-button block"
                                 :class="{ active: $route.path === '/items' }"
                                 ><i class="fa-solid fa-box-archive"></i> {{ $t('items') }}
                             </router-link>
                             <router-link
-                                @click="
-                                    () => {
-                                        toggleDropdown();
-                                        close();
-                                    }
-                                "
+                                @click="close"
                                 to="/tracker"
                                 class="nav-button block"
                                 :class="{ active: $route.path === '/tracker' }"
@@ -192,36 +152,21 @@ watchEffect(() => {
                                 {{ $t('summon-tracker') }}
                             </router-link>
                             <router-link
-                                @click="
-                                    () => {
-                                        toggleDropdown();
-                                        close();
-                                    }
-                                "
+                                @click="close"
                                 to="/planner"
                                 class="nav-button block"
                                 :class="{ active: $route.path === '/planner' }"
                                 ><i class="fas fa-tasks"></i> {{ $t('planner') }}
                             </router-link>
                             <router-link
-                                @click="
-                                    () => {
-                                        toggleDropdown();
-                                        close();
-                                    }
-                                "
+                                @click="close"
                                 to="/stages"
                                 class="nav-button block"
                                 :class="{ active: $route.path === '/stages' }"
                                 ><i class="fa-solid fa-wand-magic-sparkles"></i> {{ $t('stages') }}
                             </router-link>
                             <router-link
-                                @click="
-                                    () => {
-                                        toggleDropdown();
-                                        close();
-                                    }
-                                "
+                                @click="close"
                                 to="/profile"
                                 class="nav-button block"
                                 :class="{ active: $route.path === '/profile' }"

--- a/src/components/planner/PlannerEdit.vue
+++ b/src/components/planner/PlannerEdit.vue
@@ -305,16 +305,10 @@ const goalLevelOptions = computed(() => {
 const currentResonanceOptions = computed(() => {
     if (selectedCurrentInsight.value === null) return [];
     if (selectedCurrentInsight.value === 0) {
-        // FIXME:
-        // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-        selectedCurrentResonance.value = 0;
         return [0];
     }
     const insightValue = Number(selectedCurrentInsight.value);
     if (insightValue === 0) {
-        // FIXME:
-        // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-        selectedCurrentResonance.value = 0;
         return [];
     }
     const upperLimit = insightValue * 5;
@@ -324,17 +318,11 @@ const currentResonanceOptions = computed(() => {
 const goalResonanceOptions = computed(() => {
     if (selectedGoalInsight.value === null) return [];
     if (selectedGoalInsight.value === 0) {
-        // FIXME:
-        // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-        selectedGoalResonance.value = 0;
         return [0];
     }
     const insightValue = Number(selectedGoalInsight.value);
     const currentResonance = Number(selectedCurrentResonance.value);
     if (insightValue === 0) {
-        // FIXME:
-        // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-        selectedGoalResonance.value = 0;
         return [];
     }
     const lowerLimit = currentResonance || 1; // Start from selectedCurrentResonance or 1 if not set
@@ -365,6 +353,18 @@ const currentMasteryOptions = computed(() => {
 
 const goalMasteryOptions = computed(() => {
     return [0, 1, 2, 3, 4].filter((mastery) => mastery >= selectedCurrentMastery.value);
+});
+
+watch(selectedCurrentInsight, (newInsight) => {
+    if (newInsight === 0) {
+        selectedCurrentResonance.value = 0;
+    }
+});
+
+watch(selectedGoalInsight, (newInsight) => {
+    if (newInsight === 0) {
+        selectedGoalResonance.value = 0;
+    }
 });
 
 watch(

--- a/src/components/planner/PlannerResult.vue
+++ b/src/components/planner/PlannerResult.vue
@@ -54,6 +54,7 @@ watchEffect(async () => {
                         <br>
                         <br>
                         <i18n-t
+                            scope="global"
                             keypath="the-resources-and-insight-sections-are-straightforward-and-they-show-you-how-many-times-you-need-to-run-each-stage-in-order-to-get-the-materials-based-on-your-intended-arcanist-levels-since-we-cant-farm-resonance-materials-those-are-shown-with-the-cost-associated-in-the-oneiric-shop-found-in-the-bank">
                             <template #resources>
                                 <span class="text-yellow-500">{{ $t('resources') }}</span>
@@ -65,6 +66,7 @@ watchEffect(async () => {
                         <br>
                         <br>
                         <i18n-t
+                            scope="global"
                             keypath="the-other-two-sections-are-hard-stages-and-crafting-these-results-have-been-optimized-to-reduce-the-stamina-required-for-farming-these-materials-by-running-the-listed-stages-the-number-of-times-it-suggests-it-is-expected-you-will-receive-all-the-materials-you-need-the-materials-obtained-from-the-hard-stage-farming-will-help-you-make-the-items-listed-in-the-crafting-section">
                             <template #hardstages>
                                 <span class="text-purple-500">{{ $t('hard-stages') }}</span>
@@ -81,6 +83,7 @@ watchEffect(async () => {
                         <br>
                         <br>
                         <i18n-t
+                            scope="global"
                             keypath="please-note-that-we-do-not-know-exact-drop-rates-so-we-can-only-show-what-youre-expected-to-get-not-what-you-will-get-exactly-the-hard-stages-section-will-also-show-any-drop-that-you-may-get-rather-than-only-the-items-that-you-need-this-does-not-affect-the-results-of-the-farm-plan">
                             <template #expected>
                                 <span class="text-red-500"> {{ $t('expected') }} </span>

--- a/src/components/planner/PlannerSelector.vue
+++ b/src/components/planner/PlannerSelector.vue
@@ -72,7 +72,7 @@ const totalMaterials = computed(() => {
 
         <p v-if="arcanistsLength > 0" class="text-center text-slate-300 text-sm opacity-70">{{ $t('left-click-to-edit-right-click-to-show-hide') }}</p>
         <p v-else class="text-center text-slate-300 text-sm opacity-70">
-            <i18n-t keypath='click-add-arcanist-button-to-start-planning'>
+            <i18n-t scope="global" keypath='click-add-arcanist-button-to-start-planning'>
                 <template #button>
                     <span>{{ $t('add-arcanist') }}</span>
                 </template>

--- a/src/components/planner/PlannerSelector.vue
+++ b/src/components/planner/PlannerSelector.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts" name="PlannerSelector">
 import { ref, computed } from 'vue';
 import { useCalculation, mergeResults, formatResultsWithCasket } from '@/composables/calculations';
+import { useScreen } from '@/composables/useScreen';
 import { ISelectedArcanist } from '@/types';
 import ArcanistIconToggle from '@/components/arcanist/ArcanistIconToggle.vue';
 import ItemGoalIcon from '@/components/item/ItemGoalIcon.vue';
@@ -15,6 +16,7 @@ const props = defineProps({
 const emit = defineEmits(['open-edit-overlay']);
 
 const arcanists = ref(props.selectedArcanists);
+const { hasFinePointer } = useScreen();
 
 const handleLeftClick = (arcanist: ISelectedArcanist) => {
     emit('open-edit-overlay', arcanist);
@@ -70,13 +72,15 @@ const totalMaterials = computed(() => {
             </div>
         </div>
 
-        <p v-if="arcanistsLength > 0" class="text-center text-slate-300 text-sm opacity-70">{{ $t('left-click-to-edit-right-click-to-show-hide') }}</p>
-        <p v-else class="text-center text-slate-300 text-sm opacity-70">
+        <div v-if="arcanistsLength === 0" class="text-center text-slate-300 text-sm opacity-70">
             <i18n-t scope="global" keypath='click-add-arcanist-button-to-start-planning'>
                 <template #button>
                     <span>{{ $t('add-arcanist') }}</span>
                 </template>
             </i18n-t>
+        </div>
+        <p v-else-if="hasFinePointer" class="text-center text-slate-300 text-sm opacity-70">
+            {{ $t('left-click-to-edit-right-click-to-show-hide') }}
         </p>
     </div>
 </template>

--- a/src/components/planner/PlannerWarehouse.vue
+++ b/src/components/planner/PlannerWarehouse.vue
@@ -192,7 +192,7 @@ onMounted(() => {
                 <dialog ref="dialog" class="modal">
                     <div class="modal-box custom-gradient-gray-blue custom-border">
                         <p class="py-4 text-lg text-white text-center">
-                            <i18n-t keypath="reset-quantity-of-selected-categories">
+                            <i18n-t scope="global" keypath="reset-quantity-of-selected-categories">
                                 <template #highlight>
                                     <span class="text-error">{{ $t('selected') }}</span>
                                 </template>

--- a/src/components/planner/result/MaterialItem.vue
+++ b/src/components/planner/result/MaterialItem.vue
@@ -122,7 +122,7 @@ const isLowerBuildMaterial = computed(() => materialItem.value?.Category === 'Bu
             <div class="flex items-center justify-center flex-col">
                 <p v-if="props.layerId === 1 || props.layerId === 2" class="text-center text-slate-300 text-sm opacity-80">
                     <!-- just a sum of the current values of a given mat in the LP result -->
-                    <i18n-t keypath="numbers-expected-to-drop">
+                    <i18n-t scope="global" keypath="numbers-expected-to-drop">
                         <template #numbers>
                             <span class="text-white">{{ props.material.Quantity }}</span>
                         </template>
@@ -130,7 +130,7 @@ const isLowerBuildMaterial = computed(() => materialItem.value?.Category === 'Bu
                 </p>
                 <p v-if="props.layerId === 3" class="text-center text-slate-300 text-sm opacity-80">
                     <!-- only consider warehouseQuantityShift for crafting -->
-                    <i18n-t keypath="numbers-expected-to-be-crafted">
+                    <i18n-t scope="global" keypath="numbers-expected-to-be-crafted">
                         <template #numbers>
                             <span class="text-white">{{ Math.max(props.material.Quantity - warehouseQuantityShift,
                                 0) }}</span>
@@ -139,7 +139,7 @@ const isLowerBuildMaterial = computed(() => materialItem.value?.Category === 'Bu
                 </p>
 
                 <p class="text-center text-slate-300 text-sm opacity-80">
-                    <i18n-t keypath="numbers-needed-to-complete-the-goal">
+                    <i18n-t scope="global" keypath="numbers-needed-to-complete-the-goal">
                         <template #numbers>
                             <span class="text-white">{{ neededQuantityIncludingCraft }}</span>
                         </template>
@@ -148,7 +148,7 @@ const isLowerBuildMaterial = computed(() => materialItem.value?.Category === 'Bu
 
                 <p v-if="(isLowerBuildMaterial || props.material.Material === 'Sharpodonty') && neededQuantityForCraftingHigherTier > 0"
                     class="text-center text-slate-300 text-sm opacity-80">
-                    <i18n-t keypath="with-numbers-used-in-crafting">
+                    <i18n-t scope="global" keypath="with-numbers-used-in-crafting">
                         <template #numbers>
                             <span class="text-white">{{ neededQuantityForCraftingHigherTier }}</span>
                         </template>

--- a/src/components/planner/result/WarehouseItemEditor.vue
+++ b/src/components/planner/result/WarehouseItemEditor.vue
@@ -56,7 +56,7 @@ watchEffect(() => {
                 <img :src="normalizedMaterial.borderImagePath" alt="Border Image" class="w-20 h-20 absolute" />
                 <img :src="normalizedMaterial.itemImagePath" alt="Material Image" class="w-20 h-20 avatar" />
             </div>
-            <input v-model="quantity" @input="updateQuantity" type="text" placeholder=""
+            <input v-model="quantity" @input="updateQuantity" type="number" inputmode="numeric" step=1 min=0 placeholder=""
                 class="bg-slate-600 text-white w-14 input input-xs rounded-none text-center absolute right-3 bottom-6" />
             <div class="flex items-center justify-center font-bold w-20 mt-3">
                 <button

--- a/src/components/planner/warehouse/WarehouseItem.vue
+++ b/src/components/planner/warehouse/WarehouseItem.vue
@@ -40,7 +40,7 @@ watch(() => props.material, (newValue) => {
                 :class="{ 'w-36': normalizedMaterial.material === 'Sharpodonty' || normalizedMaterial.material === 'Dust' }" />
             <img :src="normalizedMaterial.itemImagePath" alt="Material Image" class="w-20 h-20 avatar"
                 :class="{ 'mx-5': normalizedMaterial.material === 'Sharpodonty' || normalizedMaterial.material === 'Dust' }" />
-            <input v-model="quantity" @input="updateQuantity" type="text" placeholder=""
+            <input v-model="quantity" @input="updateQuantity" type="number" inputmode="numeric" step=1 min=0 placeholder=""
                 class="bg-slate-600 text-white absolute -bottom-3 left-3 w-14 input input-xs rounded-t-none text-center"
                 :class="{
                     'left-[17px] w-[85px]': normalizedMaterial.material === 'Sharpodonty' || normalizedMaterial.material === 'Dust'

--- a/src/components/tracker/TrackerTutorial.vue
+++ b/src/components/tracker/TrackerTutorial.vue
@@ -19,6 +19,7 @@
                 <p class=" text-white">1. {{ $t('take-screenshots-of-your-summon-history') }}</p>
                 <p class=" text-white">2.
                     <i18n-t
+                        scope="global"
                         keypath="upload-the-screenshots-to-the-summon-tracker-you-could-upload-multiple-images-at-once">
                         <template #highlight>
                             <span class="text-error">{{ $t('multiple-images') }}</span>
@@ -32,7 +33,7 @@
                 <p class=" text-white">• {{ $t('it-is-advised-to-save-your-screenshots-for-future-usages') }}</p>
                 <p class=" text-white">• {{ $t('after-your-first-import') }}</p>
                 <p class="text-white">•
-                    <i18n-t keypath='this-is-an-example-of-a-good-image'>
+                    <i18n-t scope="global" keypath='this-is-an-example-of-a-good-image'>
                         <template #highlight>
                             <a href="https://imgur.com/a/cHqOqJL" target="_blank"
                                 class="text-blue-500 hover:text-blue-700">{{ $t('image') }}</a>
@@ -42,6 +43,7 @@
                 <h3 class="font-bold text-lg pt-4 text-info">{{ $t('limitations') }}</h3>
                 <p class="text-white">•
                     <i18n-t
+                        scope="global"
                         keypath="ocr-import-only-works-with-english-text-consider-changing-your-language-into-english-to-screenshot">
                         <template #highlight>
                             <span class="text-error">{{ $t('english-text') }}</span>
@@ -52,6 +54,7 @@
                 <p class="text-white">• {{ $t('try-legacy') }}</p>
                 <p class=" text-white">•
                     <i18n-t
+                        scope="global"
                         keypath='if-you-encounter-a-bug-pinpoint-its-location-by-using-missing-information-timestamps'>
                         <template #missing>
                             <span class="text-error">{{ $t('missing-information') }}</span>
@@ -59,7 +62,7 @@
                     </i18n-t>
                 </p>
                 <p class="text-white">•
-                    <i18n-t keypath='solution-1'>
+                    <i18n-t scope="global" keypath='solution-1'>
                         <template #editor>
                             <span class="text-error">{{ $t('summon-editor') }}</span>
                         </template>

--- a/src/composables/gApi.ts
+++ b/src/composables/gApi.ts
@@ -59,6 +59,11 @@ export class GApiSvc {
         // console.log('init scriptLoaded:' + scriptLoaded.value);
 
         return new Promise<void>((resolve, reject) => {
+            if (!import.meta.env.VITE_GOOGLE_CLIENT_ID) {
+                // If client ID is not set, resolve without initializing GApi.
+                return resolve();
+            }
+
             watchEffect(() => {
                 if (scriptLoaded.value) { // Check if the script is loaded
                     // eslint-disable-next-line no-undef
@@ -79,19 +84,19 @@ export class GApiSvc {
     }
 
     static async signIn () {
-        return gapi.auth2.getAuthInstance().signIn();
+        return gapi.auth2?.getAuthInstance().signIn();
     }
 
     static async signOut () {
-        return gapi.auth2.getAuthInstance().signOut();
+        return gapi.auth2?.getAuthInstance().signOut();
     }
 
     static async isSignedIn () {
-        return gapi.auth2.getAuthInstance().isSignedIn.get();
+        return gapi.auth2?.getAuthInstance().isSignedIn.get();
     }
 
     static getEmail () {
-        return gapi.auth2.getAuthInstance().currentUser.get().getBasicProfile().getEmail();
+        return gapi.auth2?.getAuthInstance()?.currentUser.get().getBasicProfile().getEmail();
     }
 
     static async getFiles () {

--- a/src/composables/useScreen.ts
+++ b/src/composables/useScreen.ts
@@ -1,0 +1,16 @@
+import { ref, onMounted, onUnmounted } from 'vue';
+
+export const MENU_BREAKPOINT = 1024;
+
+export function useScreen() {
+    const isLargeScreen = ref(window.innerWidth >= MENU_BREAKPOINT);
+
+    const updateScreenSize = () => {
+        isLargeScreen.value = window.innerWidth >= MENU_BREAKPOINT;
+    };
+
+    onMounted(() => window.addEventListener('resize', updateScreenSize));
+    onUnmounted(() => window.removeEventListener('resize', updateScreenSize));
+
+    return { isLargeScreen };
+}

--- a/src/composables/useScreen.ts
+++ b/src/composables/useScreen.ts
@@ -4,13 +4,15 @@ export const MENU_BREAKPOINT = 1024;
 
 export function useScreen() {
     const isLargeScreen = ref(window.innerWidth >= MENU_BREAKPOINT);
+    const hasFinePointer = ref(window.matchMedia('(pointer: fine)').matches);
 
     const updateScreenSize = () => {
         isLargeScreen.value = window.innerWidth >= MENU_BREAKPOINT;
+        hasFinePointer.value = window.matchMedia('(pointer: fine)').matches;
     };
 
     onMounted(() => window.addEventListener('resize', updateScreenSize));
     onUnmounted(() => window.removeEventListener('resize', updateScreenSize));
 
-    return { isLargeScreen };
+    return { isLargeScreen, hasFinePointer };
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts" name="HomeView">
-import { onMounted, onUnmounted, ref } from 'vue';
+import { onMounted, ref } from 'vue';
 import { onClickOutside } from '@vueuse/core';
 import { useChangelogsStore } from '@/stores/global';
 import { changelogs } from '@/utils/changelogs';
 import HomeChangelogs from '@/components/home/HomeChangelogs.vue';
 import HomeResources from '@/components/home/HomeResources.vue';
+import { useScreen } from '@/composables/useScreen';
 
 const changelogsStore = useChangelogsStore();
 const isChangeLogs = ref(false);
 const isResources = ref(false);
 const changelogsRef = ref(null);
 const resourcesRef = ref(null);
-const isMediumScreen = ref(window.innerWidth >= 768);
+const { isLargeScreen } = useScreen();
 const carouselItems = [
     {
         link: 'https://www.pixiv.net/en/artworks/110046834',
@@ -35,20 +36,11 @@ const closeResources = () => {
     isResources.value = false;
 };
 
-const updateScreenSize = () => {
-    isMediumScreen.value = window.innerWidth >= 768;
-};
-
 onMounted(() => {
-    window.addEventListener('resize', updateScreenSize);
     if (changelogs[0].date !== changelogsStore.lastChangelogs) {
         openChangelogs();
         changelogsStore.setLastChangelogs(changelogs[0].date);
     }
-});
-
-onUnmounted(() => {
-    window.removeEventListener('resize', updateScreenSize);
 });
 
 onClickOutside(changelogsRef, closeChangelogs);
@@ -65,7 +57,7 @@ onClickOutside(resourcesRef, closeResources);
             <p class="text-xs sm:text-base text-gray-300">
                 {{ $t('any-help-sharing-this-tool-would-be-greated-appreciated') }}
             </p>
-            <p class="text-xs sm:text-base text-gray-300" v-if="!isMediumScreen">
+            <p class="text-xs sm:text-base text-gray-300" v-if="!isLargeScreen">
                 <i18n-t keypath="for-mobile-users-click-top-right-to-start">
                     <template #mobile>
                         <i class="fa-solid fa-mobile-screen-button"></i>

--- a/src/views/PlannerView.vue
+++ b/src/views/PlannerView.vue
@@ -18,6 +18,7 @@ import PlannerWilderness from '@/components/planner/PlannerWilderness.vue'
 import PlannerWarehouse from '@/components/planner/PlannerWarehouse.vue'
 import PlannerSettings from '@/components/planner/PlannerSettings.vue'
 import PlannerTotal from '@/components/planner/PlannerTotal.vue'
+import { initializeWarehouse } from '@/composables/warehouse'
 import PlannerResult from '@/components/planner/PlannerResult.vue'
 import ArcanistAddArcanistList from '@/components/arcanist/ArcanistAddArcanistList.vue'
 
@@ -180,6 +181,7 @@ watchEffect(() => {
 onMounted(() => {
     window.addEventListener('resize', updateScreenSize);
     updateScreenSize();
+    initializeWarehouse();
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
This ended up being a mix of things. Originally this was just supposed to be fixing the lack of a mobile numeric keyboard, but I got a little sidetracked with other small things I noticed.

## Changes for mobile
- Quantity for the warehouse inputs is now numeric
  - The correct mobile keyboard will be shown
  - Arbitrary characters from the keyboard are rejected
  - A minimum value of 0 and step size of 1 are labelled on the input
  - A follow up commit removed the default up/down spinners that the browser only shows in desktop mode
  - Note: I considered allowing k,m,b suffixes, but I decided that those values being immediately converted back to a number wasn't good ux. So I didn't end up adding that enhancement.
- The "if on mobile, look for menu in top right" message disappeared at narrower widths than the menu itself switched over.
  - The logic for tracking screen width went into a new composable
  - This composable also offers a ref for the browser agent having a fine pointer (mouse) as opposed to a coarse one (finger)
- If a user doesn't have a fine pointer, the planner text about "left or right click" doesn't make sense, so it is now hidden.

## General bug fixes
- If a user hasn't visited the warehouse modal, they couldn't edit warehouse quantities from the main planner page.
  - To fix this, I just added a call to initializeWarehouse in the plannerView. I decided against removing the initialize/check logic in the warehouse modal. I wasn't sure why initialize and check are distinct, so I didn't know whether I should leave them both or just the check function.

## Dev QoL
- Reduce warnings in the dev window
  - gapi is no longer loaded if there is no client id set in the environment
  - I changed a bunch of i18n-t blocks to use scope=global. This avoids the wall of warnings about falling back to global scope.
- Changed a getter function into a reactive value. Theoretically it improves performance by only recomputing when the value changes, but it probably doesn't make any real difference.
- There were some FIXMEs about vue/no-side-effects-in-computed-properties. I moved the update logic to watch functions.

I hope these changes are helpful!